### PR TITLE
Fix Supabase cookie parsing in browser client

### DIFF
--- a/frontend/src/lib/supabase/client.ts
+++ b/frontend/src/lib/supabase/client.ts
@@ -18,15 +18,21 @@ export function createClient() {
           }
 
           // Parse cookies from document.cookie
-          const cookies = document.cookie.split('; ').reduce((acc, cookie) => {
-            const [name, value] = cookie.split('=')
-            if (name && value) {
-              acc.push({ name, value })
-            }
-            return acc
-          }, [] as { name: string; value: string }[])
+          return document.cookie
+            .split('; ')
+            .filter(Boolean)
+            .map(cookie => {
+              const separatorIndex = cookie.indexOf('=')
 
-          return cookies
+              if (separatorIndex === -1) {
+                return { name: cookie, value: '' }
+              }
+
+              const name = cookie.slice(0, separatorIndex)
+              const value = cookie.slice(separatorIndex + 1)
+
+              return { name, value }
+            })
         },
         setAll(cookiesToSet) {
           // Only set cookies in browser environment
@@ -35,8 +41,16 @@ export function createClient() {
           }
 
           cookiesToSet.forEach(({ name, value, options = {} }) => {
-            const cookieStr = `${name}=${value}; path=${options.path || '/'}; max-age=${options.maxAge || 31536000}; SameSite=${options.sameSite || 'Lax'}`
-            document.cookie = cookieStr
+            const cookieAttributes = [
+              `${name}=${value}`,
+              `Path=${options.path ?? '/'}`,
+              options.maxAge ? `Max-Age=${options.maxAge}` : undefined,
+              options.expires ? `Expires=${options.expires.toUTCString()}` : undefined,
+              `SameSite=${options.sameSite ?? 'Lax'}`,
+              options.secure ? 'Secure' : undefined,
+            ].filter(Boolean)
+
+            document.cookie = cookieAttributes.join('; ')
           })
         },
       },


### PR DESCRIPTION
## Summary
- ensure Supabase browser client preserves full cookie values when parsing document.cookie
- align browser cookie setter with Supabase options so secure/expiry attributes are retained

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df9d32921c83278bb94e865131c712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of cookie handling in the browser, ensuring cookies are parsed correctly even with unusual separators or missing values.
  * More consistent cookie setting with proper inclusion of Path, Max-Age, Expires, SameSite, and Secure when applicable.
  * Reduces edge-case errors and increases stability without changing any public APIs or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->